### PR TITLE
feat: machine state management

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -28,8 +28,8 @@ resource "paperspace_machine" "example" {
 
 ### Required
 
-- `disk_size` (Number) The disk size in gigabytes.
-- `machine_type` (String) The machine type.
+- `disk_size` (Number) The disk size in gigabytes. Updates to this field will trigger a stop/start of the machine.
+- `machine_type` (String) The machine type. Updates to this field will trigger a stop/start of the machine.
 - `name` (String) The name of the new machine.
 - `region` (String) The region to create the machine in.
 - `template_id` (String) The template ID.
@@ -46,9 +46,9 @@ resource "paperspace_machine" "example" {
 - `email_password` (Boolean) Whether to email the password. Applies only on resource creation.
 - `enable_nvlink` (Boolean) Whether to enable NVLink.
 - `network_id` (String) The network ID. You can migrate machines between private networks and from the default network to a private network. It is not possible to migrate a machine back to the default network. If this is required, please file a support ticket.
-- `public_ip_type` (String) The public IP type. Possible value: `static`, `dynamic`, `none`.
-- `start_on_create` (Boolean) Whether to start the machine on creation.
+- `public_ip_type` (String) The public IP type. Possible values: `static`, `dynamic`, `none`.
 - `startup_script_id` (String) The startup script ID. Forces resource replacement if changed.
+- `state` (String) Desired state of the machine. Possible values: `off`, `ready`.
 - `take_initial_snapshot` (Boolean) Whether to take an initial snapshot. Applies only on resource creation.
 
 ### Read-Only
@@ -66,7 +66,6 @@ resource "paperspace_machine" "example" {
 - `restore_point_enabled` (Boolean) Whether to use initial snapshot as a restore point.
 - `restore_point_frequency` (String) The restore point frequency. Possible values: `shutdown`.
 - `restore_point_snapshot_id` (String) The restore point snapshot ID.
-- `state` (String) State of the machine.
 - `storage_rate` (Number) Storage rate of the machine.
 - `storage_total` (String) Storage total of the machine.
 - `storage_used` (String) Storage used of the machine.

--- a/internal/psclient/client.go
+++ b/internal/psclient/client.go
@@ -75,7 +75,11 @@ func NewClient(host, authToken *string, ctx context.Context) (*Client, error) {
 
 func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	req.Header.Set("Authorization", "Bearer "+c.Token)
-	req.Header.Set("Content-Type", "application/json")
+
+	// Omit Content-Type header if the method is PATCH
+	if req.Method != http.MethodPatch {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/internal/psclient/machines_models.go
+++ b/internal/psclient/machines_models.go
@@ -62,7 +62,7 @@ type MachineCreateConfig struct {
 	Region                string `json:"region"`      // required
 	NetworkID             string `json:"networkId,omitempty"`
 	PublicIPType          string `json:"publicIpType,omitempty"`
-	StartOnCreate         *bool  `json:"startOnCreate,omitempty"`
+	StartOnCreate         bool   `json:"startOnCreate"`
 	AutoSnapshotEnabled   *bool  `json:"autoSnapshotEnabled,omitempty"`
 	AutoSnapshotFrequency string `json:"autoSnapshotFrequency,omitempty"`
 	AutoSnapshotSaveCount *int64 `json:"autoSnapshotSaveCount,omitempty"`


### PR DESCRIPTION
[sc-32868]

- Removes `start_on_create` attr
- Adds `state` attr to manage machine state (off/ready)
- Adds logic to stop/start machine during some updates requiring this
- Extends tests
- Fixes logic of waiting for machine event to finish

